### PR TITLE
fix NETSTANDARD2_1 CS0121

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -26,7 +26,7 @@
 		<RepositoryBranch>main</RepositoryBranch>
 		<RepositoryType>Git</RepositoryType>
 		<RepositoryUrl>https://github.com/JustArchiNET/Madness.git</RepositoryUrl>
-		<TargetFramework>netstandard2.0</TargetFramework>
+		<TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
 	</PropertyGroup>
 
 	<!-- Default configuration for fast-debugging builds -->

--- a/JustArchiNET.Madness/Internal/AsyncDisposableWrapper.cs
+++ b/JustArchiNET.Madness/Internal/AsyncDisposableWrapper.cs
@@ -19,6 +19,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#if !NETSTANDARD2_1_OR_GREATER
 using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
@@ -37,3 +38,4 @@ internal sealed class AsyncDisposableWrapper : IAsyncDisposable {
 		return default(ValueTask);
 	}
 }
+#endif

--- a/JustArchiNET.Madness/StaticExtensions.cs
+++ b/JustArchiNET.Madness/StaticExtensions.cs
@@ -59,6 +59,7 @@ public static class StaticExtensions {
 		return Task.FromResult(hashAlgorithm.ComputeHash(inputStream));
 	}
 
+#if !NETSTANDARD2_1_OR_GREATER
 	[MadnessType(EMadnessType.Implementation)]
 	public static IAsyncDisposable ConfigureAwait(this IDisposable source, bool continueOnCapturedContext) {
 		if (source == null) {
@@ -67,6 +68,7 @@ public static class StaticExtensions {
 
 		return new AsyncDisposableWrapper(source, continueOnCapturedContext);
 	}
+#endif
 
 	/// <summary>
 	///     Configures a <see cref="IWebHostBuilder" /> with defaults for hosting a web app.


### PR DESCRIPTION
Fix extension method conflict when TFM is netstandard 2.1

netstandard 2.1 is on for xamarin (Android / iOS)

https://docs.microsoft.com/en-us/dotnet/api/system.threading.tasks.taskasyncenumerableextensions.configureawait?view=netstandard-2.1

![F8CYXCC~~$L0M{4_7@H07}F](https://user-images.githubusercontent.com/24450093/144711346-aeca7234-7fa5-4a4f-a69a-67b656520b8e.png)


