### PR TITLE
Fix compiler not inlining strings

### DIFF
--- a/JustArchiNET.Madness/CallerArgumentExpressionAttribute.cs
+++ b/JustArchiNET.Madness/CallerArgumentExpressionAttribute.cs
@@ -23,7 +23,7 @@ using System;
 using JetBrains.Annotations;
 using JustArchiNET.Madness.Helpers;
 
-namespace JustArchiNET.Madness;
+namespace System.Runtime.CompilerServices;
 
 /// <inheritdoc />
 /// <summary>


### PR DESCRIPTION
This is a follow-up of #19

The dotnet compiler does not care which assembly the attribute is in, but it very much cares which namespace it is in. For this reason, we need to move the `CallerArgumentExpressionAttribute` to `System.Runtime.CompilerServices`. I am very sorry for the inconvenience.