### PR TITLE
fix RuntimeMadness.ProcessStartTime on Xamarin.Android & net6.0-android

### DIFF
--- a/JustArchiNET.Madness/RuntimeMadness.cs
+++ b/JustArchiNET.Madness/RuntimeMadness.cs
@@ -1,4 +1,4 @@
-﻿//                             _         __  __
+//                             _         __  __
 //  ___  ___   ___  _ __    __| |  __ _ |  \/  |
 // / __|/ __| / _ \| '_ \  / _` | / _` || |\/| |
 // \__ \\__ \|  __/| | | || (_| || (_| || |  | |
@@ -53,15 +53,20 @@ public static class RuntimeMadness {
 	[MadnessType(EMadnessType.Extension)]
 	public static DateTime ProcessStartTime {
 		get {
-			if (IsRunningOnMono) {
-				return SavedProcessStartTime;
+			if (!UseSavedProcessStartTime) {
+				try {
+					using Process process = Process.GetCurrentProcess();
+
+					return process.StartTime;
+				} catch {
+					UseSavedProcessStartTime = true;
+				}
 			}
 
-			using Process process = Process.GetCurrentProcess();
-
-			return process.StartTime;
+			return SavedProcessStartTime;
 		}
 	}
 
+	private static bool UseSavedProcessStartTime;
 	private static readonly DateTime SavedProcessStartTime = DateTime.UtcNow;
 }


### PR DESCRIPTION
https://github.com/dotnet/runtime/issues/67583

```
android.runtime.JavaProxyThrowable: System.UnauthorizedAccessException: Access to the path '/proc/stat' is denied.
     ---> System.IO.IOException: Permission denied
       --- End of inner exception stack trace ---
        at Interop.ThrowExceptionForIoErrno(ErrorInfo errorInfo, String path, Boolean isDirectory, Func`2 errorRewriter)
        at Interop.CheckIo(Error error, String path, Boolean isDirectory, Func`2 errorRewriter)
        at Microsoft.Win32.SafeHandles.SafeFileHandle.Open(String path, OpenFlags flags, Int32 mode)
        at Microsoft.Win32.SafeHandles.SafeFileHandle.Open(String fullPath, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize)
        at System.IO.Strategies.OSFileStreamStrategy..ctor(String path, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize)
        at System.IO.Strategies.UnixFileStreamStrategy..ctor(String path, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize)
        at System.IO.Strategies.FileStreamHelpers.ChooseStrategyCore(String path, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize)
        at System.IO.Strategies.FileStreamHelpers.ChooseStrategy(FileStream fileStream, String path, FileMode mode, FileAccess access, FileShare share, Int32 bufferSize, FileOptions options, Int64 preallocationSize)
        at System.IO.FileStream..ctor(String path, FileMode mode, FileAccess access, FileShare share, Int32 bufferSize, FileOptions options, Int64 preallocationSize)
        at System.IO.FileStream..ctor(String path, FileMode mode, FileAccess access, FileShare share, Int32 bufferSize, FileOptions options)
        at System.IO.FileStream..ctor(String path, FileMode mode, FileAccess access, FileShare share, Int32 bufferSize, Boolean useAsync)
        at System.IO.FileStream..ctor(String path, FileMode mode, FileAccess access, FileShare share, Int32 bufferSize)
        at System.IO.StreamReader.ValidateArgsAndOpenPath(String path, Encoding encoding, Int32 bufferSize)
        at System.IO.StreamReader..ctor(String path, Encoding encoding, Boolean detectEncodingFromByteOrderMarks, Int32 bufferSize)
        at System.IO.StreamReader..ctor(String path, Encoding encoding, Boolean detectEncodingFromByteOrderMarks)
        at System.IO.File.InternalReadAllText(String path, Encoding encoding)
        at System.IO.File.ReadAllText(String path)
        at System.Diagnostics.Process.get_BootTime()
        at System.Diagnostics.Process.BootTimeToDateTime(TimeSpan timespanAfterBoot)
        at System.Diagnostics.Process.get_StartTimeCore()
        at System.Diagnostics.Process.get_StartTime()
```